### PR TITLE
Allow underscores in package name

### DIFF
--- a/downgrade.jl
+++ b/downgrade.jl
@@ -10,7 +10,7 @@ function downgrade(file, ignore_pkgs, strict)
             continue
         elseif compat
             # parse the compat line
-            m = match(r"^([A-Za-z0-9]+)( *= *\")([^\"]*)(\".*)", line)
+            m = match(r"^([A-Za-z0-9_]+)( *= *\")([^\"]*)(\".*)", line)
             if m === nothing
                 error("cannot parse compat line: $line")
             end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -19,3 +19,6 @@ Pkg9 = "^1.2.3"
 Pkg10 = "~1.2.3"
 Pkg11 = "=1.2.3"
 Pkg12 = "^1, ~2, =3"
+
+# package with underscore
+Pkg13_jll = "1.2.3"


### PR DESCRIPTION
Thank you very much for this nice GitHub action @cjdoris! I have noticed that packages containing underscores fail, see e.g. https://github.com/trixi-framework/P4est.jl/actions/runs/7185904424/job/19570147736?pr=105#step:6:13. Since it is common for binary wrapper packages to contain a suffix "_jll" I decided to create this PR, which allows an underscore in the package name.